### PR TITLE
Fix print() of 'rma.uni' objects with R < 4.0.x.

### DIFF
--- a/R/print.rma.uni.r
+++ b/R/print.rma.uni.r
@@ -176,9 +176,25 @@ print.rma.uni <- function(x, digits, showfit=FALSE, signif.stars=getOption("show
    }
 
    if (is.element(x$test, c("knha","adhoc","t"))) {
-      res.table <- data.frame(estimate=.fcf(c(x$beta), digits[["est"]]), se=.fcf(x$se, digits[["se"]]), tval=.fcf(x$zval, digits[["test"]]), df=round(x$ddf, 2), pval=.pval(x$pval, digits[["pval"]]), ci.lb=.fcf(x$ci.lb, digits[["ci"]]), ci.ub=.fcf(x$ci.ub, digits[["ci"]]))
+      res.table <- data.frame(
+        estimate=.fcf(c(x$beta), digits[["est"]]), 
+        se=.fcf(x$se, digits[["se"]]), 
+        tval=.fcf(x$zval, digits[["test"]]), 
+        df=round(x$ddf, 2), pval=.pval(x$pval, digits[["pval"]]), 
+        ci.lb=.fcf(x$ci.lb, digits[["ci"]]), 
+        ci.ub=.fcf(x$ci.ub, digits[["ci"]]),
+        stringsAsFactors = FALSE
+      )
    } else {
-      res.table <- data.frame(estimate=.fcf(c(x$beta), digits[["est"]]), se=.fcf(x$se, digits[["se"]]), zval=.fcf(x$zval, digits[["test"]]), pval=.pval(x$pval, digits[["pval"]]), ci.lb=.fcf(x$ci.lb, digits[["ci"]]), ci.ub=.fcf(x$ci.ub, digits[["ci"]]))
+      res.table <- data.frame(
+        estimate=.fcf(c(x$beta), digits[["est"]]), 
+        se=.fcf(x$se, digits[["se"]]), 
+        zval=.fcf(x$zval, digits[["test"]]), 
+        pval=.pval(x$pval, digits[["pval"]]), 
+        ci.lb=.fcf(x$ci.lb, digits[["ci"]]), 
+        ci.ub=.fcf(x$ci.ub, digits[["ci"]]),
+        stringsAsFactors = FALSE
+      )
    }
    rownames(res.table) <- rownames(x$beta)
    signif <- symnum(x$pval, corr=FALSE, na=FALSE, cutpoints=c(0, 0.001, 0.01, 0.05, 0.1, 1), symbols = c("***", "**", "*", ".", " "))


### PR DESCRIPTION
Dear Wolfgang,

Many thanks for your workshop today. I tried the latest master version what resulted in a wrong output:

```
> example("dat.bangertdrowns2004", package = "metafor")
Loading required package: Matrix
Loading 'metafor' package (version 2.5-89). For an overview 
and introduction to the package please type: help(metafor)

d.2004> ### copy data into 'dat' and examine data
d.2004> dat <- dat.bangertdrowns2004

d.2004> dat
[... suppressed ...]

d.2004> ### random-effects model
d.2004> res <- rma(yi, vi, data=dat)

d.2004> res

Random-Effects Model (k = 48; tau^2 estimator: REML)

tau^2 (estimated amount of total heterogeneity): 0.0499 (SE = 0.0197)
tau (square root of estimated tau^2 value):      0.2235
I^2 (total heterogeneity / total variability):   58.37%
H^2 (total variability / sampling variability):  2.40

Test for Heterogeneity:
Q(df = 47) = 107.1061, p-val < .0001

Model Results:

estimate  se  zval  pval  ci.lb  ci.ub 
       1   1     1     1      1      1  *** 

---
Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
```

This is due to recent changes in R:

```
R now uses a stringsAsFactors = FALSE default, and hence by default no longer converts strings to factors in calls to data.frame() and read.table().

A large number of packages relied on the previous behaviour and so have needed/will need updating.
```

This PR fixes the wrong behavior. In short: A data frame is created with characters that are converted to factors in R < 4.0 but not in R >= 4.0. This results in different behavior in this function call `.print.vector(res.table)`.

Best