### PR TITLE
Option to show second summary estimate on forest plot

### DIFF
--- a/R/forest.rma.r
+++ b/R/forest.rma.r
@@ -1017,9 +1017,11 @@ lty, fonts, cex, cex.lab, cex.axis, ...) {
         
         # obtain estimates for other model
         temp <- predict(y, level=level, pi.type=pi.type)
+        
         beta.y       <- temp$pred
         beta.ci.lb.y <- temp$ci.lb
         beta.ci.ub.y <- temp$ci.ub
+        
         if (is.function(transf)) {
           if (is.null(targs)) {
             beta.y       <- sapply(beta.y, transf)
@@ -1031,26 +1033,33 @@ lty, fonts, cex, cex.lab, cex.axis, ...) {
             beta.ci.ub.y <- sapply(beta.ci.ub.y, transf, targs)
           }
         }
+        
         # make sure order of intervals is always increasing
+        
         tmp <- .psort(beta.ci.lb.y, beta.ci.ub.y)
         beta.ci.lb.y <- tmp[,1]
         beta.ci.ub.y <- tmp[,2]
+        
         # apply observation/outcome limits if specified
+        
         if (!missing(olim)) {
           beta.ci.lb.y[beta.ci.lb.y < olim[1]] <- olim[1]
           beta.ci.ub.y[beta.ci.ub.y > olim[2]] <- olim[2]
         }
         
         # add polygon #
+        
         lpolygon(x=c(beta.ci.lb.y, beta.y, beta.ci.ub.y, beta.y), y=c(-2, -2+(height/100)*cex*efac[3], -2, -2-(height/100)*cex*efac[3]), col=col[1], border=border, ...)
         
         # add labels
+        
         if (missing(mlab.y))
           mlab.y <- sapply(y$method, switch, "FE"="FE Model", "EE"="EE Model", "CE"="CE Model", "RE Model", USE.NAMES=FALSE)
+        
         if (is.list(mlab.y)) {
-          ltext(ddd$textpos[1], -2, mlab.y[[1]], pos=4, cex=cex, ...)
+          ltext(textpos[1], -2, mlab.y[[1]], pos=4, cex=cex, ...)
         } else {
-          ltext(ddd$textpos[1], -2, mlab.y, pos=4, cex=cex, ...)
+          ltext(textpos[1], -2, mlab.y, pos=4, cex=cex, ...)
         }
       }
 
@@ -1241,9 +1250,9 @@ lty, fonts, cex, cex.lab, cex.axis, ...) {
 
       if (addfit && x$int.only) {
         if (missing(y)) {
-          ltext(ddd$textpos[2], c(rows,-1), labels=annotext, pos=2, cex=cex, ...)
+          ltext(textpos[2], c(rows,-1)+rowadj[2], labels=annotext, pos=2, cex=cex, ...)
         } else {
-          ltext(ddd$textpos[2], c(rows,-1,-2), labels=annotext, pos=2, cex=cex, ...)
+          ltext(textpos[2], c(rows,-1,-2)+rowadj[2], labels=annotext, pos=2, cex=cex, ...)
         }
       } else {
          ltext(textpos[2], rows+rowadj[2], labels=annotext, pos=2, cex=cex, ...)

--- a/R/forest.rma.r
+++ b/R/forest.rma.r
@@ -964,12 +964,12 @@ lty, fonts, cex, cex.lab, cex.axis, ...) {
       tmp <- .psort(beta.pi.lb, beta.pi.ub)
       beta.pi.lb <- tmp[,1]
       beta.pi.ub <- tmp[,2]
-
+      
       ### apply observation/outcome limits if specified
 
       if (!missing(olim)) {
-         pred[pred < olim[1]] <- olim[1]
-         pred[pred > olim[2]] <- olim[2]
+         beta[beta < olim[1]] <- olim[1]
+         beta[beta > olim[2]] <- olim[2]
          beta.ci.lb[beta.ci.lb < olim[1]] <- olim[1]
          beta.ci.ub[beta.ci.ub > olim[2]] <- olim[2]
          beta.pi.lb[beta.pi.lb < olim[1]] <- olim[1]
@@ -1017,7 +1017,7 @@ lty, fonts, cex, cex.lab, cex.axis, ...) {
         
         # obtain estimates for other model
         if (inherits(y, "rma.mv") && y$withG && y$tau2s > 1) {
-
+          
           if (!is.logical(addpred)) {
             ### for multiple tau^2 (and gamma^2) values, need to specify level(s) of the inner factor(s) to compute the PI
             ### this can be done via the addpred argument (i.e., instead of using a logical, one specifies the level(s))
@@ -1034,11 +1034,11 @@ lty, fonts, cex, cex.lab, cex.axis, ...) {
               temp <- predict(y, level=level, tau2.levels=1, gamma2.levels=1, pi.type=pi.type)
             }
           }
-
+          
         } else {
-
+          
           temp <- predict(y, level=level, pi.type=pi.type)
-
+          
         }
         
         beta.y       <- temp$pred
@@ -1076,8 +1076,8 @@ lty, fonts, cex, cex.lab, cex.axis, ...) {
         # apply observation/outcome limits if specified
         
         if (!missing(olim)) {
-          pred[pred < olim[1]] <- olim[1]
-          pred[pred > olim[2]] <- olim[2]
+          beta.y[beta.y < olim[1]] <- olim[1]
+          beta.y[beta.y > olim[2]] <- olim[2]
           beta.ci.lb.y[beta.ci.lb.y < olim[1]] <- olim[1]
           beta.ci.ub.y[beta.ci.ub.y > olim[2]] <- olim[2]
           beta.pi.lb.y[beta.pi.lb.y < olim[1]] <- olim[1]
@@ -1085,24 +1085,28 @@ lty, fonts, cex, cex.lab, cex.axis, ...) {
         }
         
         ### add prediction interval
-
+        
         if (!is.element(y$method, c("FE","EE","CE")) && addpred) {
-
-          lsegments(max(beta.pi.lb.y, alim[1]), -1, min(beta.pi.ub.y, alim[2]), -1, lty=lty[2], col=col[2], ...)
-
+          
+          lsegments(max(beta.pi.lb.y, alim[1]), -2, min(beta.pi.ub.y, alim[2]), -2, lty=lty[2], col=col[2], ...)
+          
           if (beta.pi.lb.y >= alim[1]) {
-            lsegments(beta.pi.lb.y, -1-(height/150)*cex*efac[1], beta.pi.lb.y, -1+(height/150)*cex*efac[1], col=col[2], ...)
+            lsegments(beta.pi.lb.y, -2-(height/150)*cex*efac[1], beta.pi.lb.y, -2+(height/150)*cex*efac[1], col=col[2], ...)
           } else {
-            lpolygon(x=c(alim[1], alim[1]+(1.4/100)*cex*(xlim[2]-xlim[1]), alim[1]+(1.4/100)*cex*(xlim[2]-xlim[1]), alim[1]), y=c(-2, -2+(height/150)*cex*efac[3], -2-(height/150)*cex*efac[3], -2), col=col[1], border=col[1], ...)
+            lpolygon(x=c(alim[1], alim[1]+(1.4/100)*cex*(xlim[2]-xlim[1]), alim[1]+(1.4/100)*cex*(xlim[2]-xlim[1]), alim[1]), y=c(-2, -2+(height/150)*cex*efac[2], -2-(height/150)*cex*efac[2], -2), col=col[2], border=col[2], ...)
           }
-
+          
           if (beta.pi.ub.y <= alim[2]) {
-            lsegments(beta.pi.ub.y, -1-(height/150)*cex*efac[1], beta.pi.ub.y, -1+(height/150)*cex*efac[1], col=col[2], ...)
+            lsegments(beta.pi.ub.y, -2-(height/150)*cex*efac[1], beta.pi.ub.y, -2+(height/150)*cex*efac[1], col=col[2], ...)
           } else {
-            lpolygon(x=c(alim[2], alim[2]-(1.4/100)*cex*(xlim[2]-xlim[1]), alim[2]-(1.4/100)*cex*(xlim[2]-xlim[1]), alim[2]), y=c(-2, -2+(height/150)*cex*efac[3], -2-(height/150)*cex*efac[3], -2), col=col[1], border=col[1], ...)
+            lpolygon(x=c(alim[2], alim[2]-(1.4/100)*cex*(xlim[2]-xlim[1]), alim[2]-(1.4/100)*cex*(xlim[2]-xlim[1]), alim[2]), y=c(-2, -2+(height/150)*cex*efac[2], -2-(height/150)*cex*efac[2], -2), col=col[2], border=col[2], ...)
           }
-
+          
         }
+        
+        ### polygon for the summary estimate
+        
+        lpolygon(x=c(beta.ci.lb.y, beta.y, beta.ci.ub.y, beta.y), y=c(-2, -2+(height/100)*cex*efac[3], -2, -2-(height/100)*cex*efac[3]), col=col[1], border=border, ...)
         
         # add labels
         

--- a/R/forest.rma.r
+++ b/R/forest.rma.r
@@ -1,7 +1,7 @@
 forest.rma       <- function(x, y,
 annotate=TRUE, addfit=TRUE, addpred=FALSE, showweights=FALSE, header=FALSE,
 xlim, alim, olim, ylim, at, steps=5, level=x$level, refline=0, digits=2L, width,
-xlab, slab, mlab, ilab, ilab.xpos, ilab.pos, order,
+xlab, slab, mlab, mlab.y, ilab, ilab.xpos, ilab.pos, order,
 transf, atransf, targs, rows,
 efac=1, pch, psize, plim=c(0.5,1.5), colout, col, border, shade, colshade,
 lty, fonts, cex, cex.lab, cex.axis, ...) {

--- a/R/forest.rma.r
+++ b/R/forest.rma.r
@@ -1093,13 +1093,13 @@ lty, fonts, cex, cex.lab, cex.axis, ...) {
           if (beta.pi.lb.y >= alim[1]) {
             lsegments(beta.pi.lb.y, -1-(height/150)*cex*efac[1], beta.pi.lb.y, -1+(height/150)*cex*efac[1], col=col[2], ...)
           } else {
-            lpolygon(x=c(alim[1], alim[1]+(1.4/100)*cex*(xlim[2]-xlim[1]), alim[1]+(1.4/100)*cex*(xlim[2]-xlim[1]), alim[1]), y=c(-1, -1+(height/150)*cex*efac[2], -1-(height/150)*cex*efac[2], -1), col=col[2], border=col[2], ...)
+            lpolygon(x=c(alim[1], alim[1]+(1.4/100)*cex*(xlim[2]-xlim[1]), alim[1]+(1.4/100)*cex*(xlim[2]-xlim[1]), alim[1]), y=c(-2, -2+(height/150)*cex*efac[3], -2-(height/150)*cex*efac[3], -2), col=col[1], border=col[1], ...)
           }
 
           if (beta.pi.ub.y <= alim[2]) {
             lsegments(beta.pi.ub.y, -1-(height/150)*cex*efac[1], beta.pi.ub.y, -1+(height/150)*cex*efac[1], col=col[2], ...)
           } else {
-            lpolygon(x=c(alim[2], alim[2]-(1.4/100)*cex*(xlim[2]-xlim[1]), alim[2]-(1.4/100)*cex*(xlim[2]-xlim[1]), alim[2]), y=c(-1, -1+(height/150)*cex*efac[2], -1-(height/150)*cex*efac[2], -1), col=col[2], border=col[2], ...)
+            lpolygon(x=c(alim[2], alim[2]-(1.4/100)*cex*(xlim[2]-xlim[1]), alim[2]-(1.4/100)*cex*(xlim[2]-xlim[1]), alim[2]), y=c(-2, -2+(height/150)*cex*efac[3], -2-(height/150)*cex*efac[3], -2), col=col[1], border=col[1], ...)
           }
 
         }

--- a/man/forest.rma.Rd
+++ b/man/forest.rma.Rd
@@ -16,9 +16,10 @@
 }
 \arguments{
    \item{x}{an object of class \code{"rma"}.}
+   \item{y}{an object of class \code{"rma"}. This is used to display a second summary estimate when \code{addfit} is set to \code{TRUE}.}
    \item{annotate}{logical to specify whether annotations should be added to the plot (the default is \code{TRUE}).}
-   \item{addfit}{logical to specify whether the summary estimate (for models without moderators) or fitted values (for models with moderators) should be added to the plot (the default is \code{TRUE}). See \sQuote{Details}.}
-   \item{addpred}{logical to specify whether the bounds of the prediction interval should be added to the plot (the default is \code{FALSE}). See \sQuote{Details}.}
+   \item{addfit}{logical to specify whether the summary estimates (for models without moderators) or fitted values (for models with moderators) should be added to the plot (the default is \code{TRUE}). See \sQuote{Details}.}
+   \item{addpred}{logical to specify whether the bounds of the prediction intervals should be added to the plot (the default is \code{FALSE}). See \sQuote{Details}.}
    \item{showweights}{logical to specify whether the annotations should also include the weights given to the observed outcomes during the model fitting (the default is \code{FALSE}). See \sQuote{Details}.}
    \item{header}{logical to specify whether column headings should be added to the plot (the default is \code{FALSE}). Can also be a character vector to specify the left and right headings  (or only the left one).}
    \item{xlim}{horizontal limits of the plot region. If unspecified, the function sets the horizontal plot limits to some sensible values.}


### PR DESCRIPTION
This was requested by a collaborator on a recent project, and I am keen to keep using the CRAN package, rather than relying on a fork which is not likely to be maintained.

The change is to allow for a second summary estimate to be plotted below the main summary estimate in the function `forest.rma()`. This allows for fixed and random effects to be shown on the same plot. I hope that this is something which fits with the ethos of this package.

I updated the documentation for the function, but I may not have done a complete job because I have not worked on an R package before this.

I also noticed a small bug where the limits were not being applied to the summary estimate diamonds properly, so I have fixed that by limiting the `beta` variable rather than the `pred` variable.

I'm happy to make any changes which would make this change compatible with {metafor}.