### PR TITLE
Some tweaks to speed up vcalc().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+metafor.Rproj

--- a/R/vcalc.r
+++ b/R/vcalc.r
@@ -1,5 +1,5 @@
 vcalc <- function(vi, cluster, subgroup, obs, type, time1, time2, grp1, grp2, w1, w2,
-data, rho, phi, rvars, checkpd=TRUE, nearpd=FALSE, sparse=FALSE, ...) {
+data, rho, phi, rvars, checkpd=TRUE, nearpd=FALSE, sparse=FALSE, ..., new = TRUE) {
 
    mstyle <- .get.mstyle()
 
@@ -346,25 +346,55 @@ data, rho, phi, rvars, checkpd=TRUE, nearpd=FALSE, sparse=FALSE, ...) {
          R <- matrix(0, nrow=k, ncol=k)
       }
 
-      diag(R) <- 1
-
-      for (i in 2:k) {
-         for (j in 1:i) {
-            if (cluster[i] == cluster[j]) {
-
-               R[i,j] <- ifelse(type[i]==type[j], ifelse(obs[i]==obs[j], 1, rho[[1]][obs[i],obs[j]]), rho[[2]][type[i],type[j]]) *
-                         (ifelse(grp1[i]==grp1[j], ifelse(time1[i]==time1[j], 1, phi^abs(time1[i]-time1[j])), 0) * sqrt(1/w1[i] * 1/w1[j]) -
-                          ifelse(grp1[i]==grp2[j], ifelse(time1[i]==time2[j], 1, phi^abs(time1[i]-time2[j])), 0) * sqrt(1/w1[i] * 1/w2[j]) -
-                          ifelse(grp2[i]==grp1[j], ifelse(time2[i]==time1[j], 1, phi^abs(time2[i]-time1[j])), 0) * sqrt(1/w2[i] * 1/w1[j]) +
-                          ifelse(grp2[i]==grp2[j], ifelse(time2[i]==time2[j], 1, phi^abs(time2[i]-time2[j])), 0) * sqrt(1/w2[i] * 1/w2[j])) /
-                         (sqrt(1/w1[i] + 1/w2[i] - 2*ifelse(grp1[i]==grp2[i], ifelse(time1[i]==time2[i], 1, phi^abs(time1[i]-time2[i])), 0) * sqrt(1/w1[i] * 1/w2[i])) *
-                          sqrt(1/w1[j] + 1/w2[j] - 2*ifelse(grp1[j]==grp2[j], ifelse(time1[j]==time2[j], 1, phi^abs(time1[j]-time2[j])), 0) * sqrt(1/w1[j] * 1/w2[j])))
-
+      if (new) {
+        cluster_set <- unique(cluster) 
+        
+        for (cl in cluster_set) {
+          cl_i <- which(cl == cluster)
+          k_c <- length(cl_i)
+          R_c <- matrix(0, nrow = k_c, ncol = k_c)
+          diag(R_c) <- 1
+          if (k_c > 1L) {
+            for (i in 2:k_c) {
+              for (j in 1:i) {
+                ci <- cl_i[i]
+                cj <- cl_i[j]
+                R_c[i,j] <- ifelse(type[ci]==type[cj], ifelse(obs[ci]==obs[cj], 1, rho[[1]][obs[ci],obs[cj]]), rho[[2]][type[ci],type[cj]]) *
+                  (ifelse(grp1[ci]==grp1[cj], ifelse(time1[ci]==time1[cj], 1, phi^abs(time1[ci]-time1[cj])), 0) * sqrt(1/w1[ci] * 1/w1[cj]) -
+                     ifelse(grp1[ci]==grp2[cj], ifelse(time1[ci]==time2[cj], 1, phi^abs(time1[ci]-time2[cj])), 0) * sqrt(1/w1[ci] * 1/w2[cj]) -
+                     ifelse(grp2[ci]==grp1[cj], ifelse(time2[ci]==time1[cj], 1, phi^abs(time2[ci]-time1[cj])), 0) * sqrt(1/w2[ci] * 1/w1[cj]) +
+                     ifelse(grp2[ci]==grp2[cj], ifelse(time2[ci]==time2[cj], 1, phi^abs(time2[ci]-time2[cj])), 0) * sqrt(1/w2[ci] * 1/w2[cj])) /
+                  (sqrt(1/w1[ci] + 1/w2[ci] - 2*ifelse(grp1[ci]==grp2[ci], ifelse(time1[ci]==time2[ci], 1, phi^abs(time1[ci]-time2[ci])), 0) * sqrt(1/w1[ci] * 1/w2[ci])) *
+                     sqrt(1/w1[cj] + 1/w2[cj] - 2*ifelse(grp1[cj]==grp2[cj], ifelse(time1[cj]==time2[cj], 1, phi^abs(time1[cj]-time2[cj])), 0) * sqrt(1/w1[cj] * 1/w2[cj])))
+              }
             }
-         }
+          }
+          R_c[upper.tri(R_c)] <- t(R_c)[upper.tri(R_c)]
+          R[cl_i, cl_i] <- R_c
+        }
+        
+      } else {
+        diag(R) <- 1
+        
+        for (i in 2:k) {
+          for (j in 1:i) {
+            if (cluster[i] == cluster[j]) {
+              
+              R[i,j] <- ifelse(type[i]==type[j], ifelse(obs[i]==obs[j], 1, rho[[1]][obs[i],obs[j]]), rho[[2]][type[i],type[j]]) *
+                (ifelse(grp1[i]==grp1[j], ifelse(time1[i]==time1[j], 1, phi^abs(time1[i]-time1[j])), 0) * sqrt(1/w1[i] * 1/w1[j]) -
+                   ifelse(grp1[i]==grp2[j], ifelse(time1[i]==time2[j], 1, phi^abs(time1[i]-time2[j])), 0) * sqrt(1/w1[i] * 1/w2[j]) -
+                   ifelse(grp2[i]==grp1[j], ifelse(time2[i]==time1[j], 1, phi^abs(time2[i]-time1[j])), 0) * sqrt(1/w2[i] * 1/w1[j]) +
+                   ifelse(grp2[i]==grp2[j], ifelse(time2[i]==time2[j], 1, phi^abs(time2[i]-time2[j])), 0) * sqrt(1/w2[i] * 1/w2[j])) /
+                (sqrt(1/w1[i] + 1/w2[i] - 2*ifelse(grp1[i]==grp2[i], ifelse(time1[i]==time2[i], 1, phi^abs(time1[i]-time2[i])), 0) * sqrt(1/w1[i] * 1/w2[i])) *
+                   sqrt(1/w1[j] + 1/w2[j] - 2*ifelse(grp1[j]==grp2[j], ifelse(time1[j]==time2[j], 1, phi^abs(time1[j]-time2[j])), 0) * sqrt(1/w1[j] * 1/w2[j])))
+              
+            }
+          }
+        }
+        
+        R[upper.tri(R)] <- t(R)[upper.tri(R)]
+        
       }
-
-      R[upper.tri(R)] <- t(R)[upper.tri(R)]
 
    } else {
 

--- a/tests/testthat/test_vcalc_timing.R
+++ b/tests/testthat/test_vcalc_timing.R
@@ -1,0 +1,30 @@
+skip_if_not_installed("clubSandwich")
+skip_if_not_installed("microbenchmark")
+
+# concoct fake dataset
+set.seed(20240815)
+studies <- 50
+vi <- 4 / (20 + rpois(studies, lambda = 30))
+n_es <- sample(1:50, size = studies, replace = TRUE)
+dat <- data.frame(
+  study = rep(1:studies, n_es),
+  esid = 1:sum(n_es),
+  vi = rep(vi, n_es)
+)
+
+# compare timings
+timings <- microbenchmark::microbenchmark(
+  "metafor-old" = vcalc(vi, cluster = study, obs = esid, data = dat, rho = 0.6, sparse = TRUE, new = FALSE),
+  "metafor-new" = vcalc(vi, cluster = study, obs = esid, data = dat, rho = 0.6, sparse = TRUE, new = TRUE),
+  "clubSandwich" = clubSandwich::impute_covariance_matrix(vi = dat$vi, cluster = dat$study, r = 0.6, return_list = TRUE),
+  times = 10
+)
+
+summary(timings)
+
+test_that("vcalc(new = TRUE) returns results equivalent to new = FALSE.", {
+  V_old <- vcalc(vi, cluster = study, obs = esid, data = dat, rho = 0.6, sparse = TRUE, new = FALSE)
+  V_new <- vcalc(vi, cluster = study, obs = esid, data = dat, rho = 0.6, sparse = TRUE, new = TRUE)
+  
+  expect_equal(V_old, V_new)
+})


### PR DESCRIPTION
Responding to [this thread](https://stat.ethz.ch/pipermail/r-sig-meta-analysis/2024-August/005374.html) on R-sig-meta-analysis, here's an approach that speeds up vcalc() for large matrices, while still retaining the for loop style. For an example similar to the reprex in Tamar's post, the changes lead to ~10x improvements in compute time (although still not as fast as `clubSandwich::impute_covariance_matrix()`).

The key differences from the current metafor implementation are 
1) Adding an outer loop over clusters, then making the inner loops specific to each cluster.
2) Storing the cluster-specific results as a basic matrix, performing the transpose on this matrix, and only then storing the result in the the sparse `R` matrix. 

There's probably a better way to store the cluster-specific matrices (as some sort of dense triangular matrix?) but I don't understand the Matrix package well enough to see how to do this.