### PR TITLE
Changed 3 dashes to 4 to avoid Quarto rendering problems.

### DIFF
--- a/R/print.deltamethod.r
+++ b/R/print.deltamethod.r
@@ -37,7 +37,7 @@ print.deltamethod <- function(x, digits=x$digits, signif.stars=getOption("show.s
 
    if (signif.legend) {
       cat("\n")
-      cat(mstyle$legend("---"))
+      cat(mstyle$legend("----"))
       cat("\n")
       cat(mstyle$legend("Signif. codes: "), mstyle$legend(attr(signif, "legend")))
       cat("\n")

--- a/R/print.permutest.rma.uni.r
+++ b/R/print.permutest.rma.uni.r
@@ -135,7 +135,7 @@ print.permutest.rma.uni <- function(x, digits=x$digits, signif.stars=getOption("
 
    if (signif.legend || legend) {
       cat("\n")
-      cat(mstyle$legend("---"))
+      cat(mstyle$legend("----"))
    }
 
    if (signif.legend) {

--- a/R/print.rma.glmm.r
+++ b/R/print.rma.glmm.r
@@ -162,7 +162,7 @@ print.rma.glmm <- function(x, digits, showfit=FALSE, signif.stars=getOption("sho
 
    if (signif.legend) {
       cat("\n")
-      cat(mstyle$legend("---"))
+      cat(mstyle$legend("----"))
       cat("\n")
       cat(mstyle$legend("Signif. codes: "), mstyle$legend(attr(signif, "legend")))
       cat("\n")

--- a/R/print.rma.mv.r
+++ b/R/print.rma.mv.r
@@ -427,7 +427,7 @@ print.rma.mv <- function(x, digits, showfit=FALSE, signif.stars=getOption("show.
 
    if (signif.legend || legend) {
       cat("\n")
-      cat(mstyle$legend("---"))
+      cat(mstyle$legend("----"))
    }
 
    if (signif.legend) {

--- a/R/print.rma.uni.r
+++ b/R/print.rma.uni.r
@@ -301,8 +301,8 @@ print.rma.uni <- function(x, digits, showfit=FALSE, signif.stars=getOption("show
       }
 
       for (j in seq_len(nrow(res.table))) {
-         res.table[j, is.na(res.table[j,])]  <- ifelse(x$alpha.fix[j], "---", "NA")
-         res.table[j, res.table[j,] == "NA"] <- ifelse(x$alpha.fix[j], "---", "NA")
+         res.table[j, is.na(res.table[j,])]  <- ifelse(x$alpha.fix[j], "----", "NA")
+         res.table[j, res.table[j,] == "NA"] <- ifelse(x$alpha.fix[j], "----", "NA")
       }
 
       if (isTRUE(ddd$num)) {
@@ -311,9 +311,9 @@ print.rma.uni <- function(x, digits, showfit=FALSE, signif.stars=getOption("show
       }
 
       if (x$randhet) {
-         res.table.omega2 <- c(fmtx(x$omega2, digits[["var"]]), fmtx(x$se.omega2, digits[["se"]]), "---", "---", fmtx(x$ci.lb.omega2, digits[["ci"]]), fmtx(x$ci.ub.omega2, digits[["ci"]]))
+         res.table.omega2 <- c(fmtx(x$omega2, digits[["var"]]), fmtx(x$se.omega2, digits[["se"]]), "----", "----", fmtx(x$ci.lb.omega2, digits[["ci"]]), fmtx(x$ci.ub.omega2, digits[["ci"]]))
          if (is.element(x$test, c("knha","adhoc","t")))
-            res.table.omega2 <- c(res.table.omega2[1:2], "---", res.table.omega2[-(1:2)])
+            res.table.omega2 <- c(res.table.omega2[1:2], "----", res.table.omega2[-(1:2)])
          if (signif.stars)
             res.table.omega2 <- c(res.table.omega2, "")
          res.table <- rbind(res.table, "omega^2"=res.table.omega2)
@@ -363,8 +363,8 @@ print.rma.uni <- function(x, digits, showfit=FALSE, signif.stars=getOption("show
       }
 
       for (j in seq_len(nrow(res.table))) {
-         res.table[j, is.na(res.table[j,])]  <- ifelse(x$delta.fix[j], "---", "NA")
-         res.table[j, res.table[j,] == "NA"] <- ifelse(x$delta.fix[j], "---", "NA")
+         res.table[j, is.na(res.table[j,])]  <- ifelse(x$delta.fix[j], "----", "NA")
+         res.table[j, res.table[j,] == "NA"] <- ifelse(x$delta.fix[j], "----", "NA")
       }
 
       if (length(x$delta) == 1L)
@@ -390,7 +390,7 @@ print.rma.uni <- function(x, digits, showfit=FALSE, signif.stars=getOption("show
 
    if (signif.legend || legend) {
       cat("\n")
-      cat(mstyle$legend("---"))
+      cat(mstyle$legend("----"))
    }
 
    if (signif.legend) {

--- a/R/reporter.rma.uni.r
+++ b/R/reporter.rma.uni.r
@@ -266,7 +266,7 @@ reporter.rma.uni <- function(x, dir, filename, format="html_document", open=TRUE
 
    ### yaml header
 
-   header <- paste0("---\n")
+   header <- paste0("----\n")
    header <- paste0(header, "output:\n")
    if (format == "html_document")
       header <- paste0(header, "  html_document:\n    toc: true\n    toc_float:\n      collapsed: false\n")

--- a/R/rma.mv.r
+++ b/R/rma.mv.r
@@ -1997,7 +1997,7 @@ cvvc=FALSE, sparse=FALSE, verbose=FALSE, digits, control, ...) {
          vcs <- data.frame(vcs, stringsAsFactors=FALSE)
          rownames(vcs) <- c("initial", "specified")
          vcs <- rbind(included=ifelse(c(rep(withS, sigma2s), rep(withG, tau2s), rep(withG, rhos), rep(withH, gamma2s), rep(withH, phis)), "Yes", "No"), fixed=unlist(vc.fix), vcs)
-         tmp <- capture.output(print(vcs, na.print="---"))
+         tmp <- capture.output(print(vcs, na.print="----"))
          .print.output(tmp, mstyle$verbose)
          cat("\n")
       }


### PR DESCRIPTION
This PR modifies the print output for rma objects to avoid using triple dashes.

Fixes wviechtb/metafor#105 

Reasoning: The --- separator currently used in the output triggers a YAML parsing error in Quarto/Pandoc when the results: asis chunk option is used, as it is interpreted as a metadata delimiter. This prevents metafor results from being printed directly in .qmd or .Rmd files.

